### PR TITLE
Service mesh allowing sharding

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,15 @@
   },
   "dependencies": {
     "@google-cloud/logging-winston": "^4.0.2",
+    "@types/uuid": "^8.3.0",
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "discord.js": "^12.5.1",
     "express": "^4.17.1",
     "nano": "^9.0.1",
+    "rxjs": "^6.6.3",
+    "uuid": "^8.3.2",
     "winston": "^3.3.3"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import dotenv from 'dotenv';
 import { LoggingWinston } from '@google-cloud/logging-winston';
 import winston from 'winston';
 import { Logger } from './util/logger';
+import { initMesh } from './services/mesh';
 
 if (process.env.NODE_ENV == null || process.env.NODE_ENV === 'develepmont') {
   dotenv.config();
@@ -23,7 +24,8 @@ if (process.env.NODE_ENV == null || process.env.NODE_ENV === 'develepmont') {
 (async () => {
   setSofa(new Sofa(process.env.COUCHDB || 'http://admin:admin@localhost:5984'));
   await sofa.doMigrations();
-
+  initMesh();
+  
   const app = applyRoutes(Express());
   app.listen(process.env.PORT || 3000, () => {
     Logger.info(`listening on localhost:${process.env.PORT || 3000}`);

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,13 @@ import { Logger } from './util/logger';
 
 if (process.env.NODE_ENV == null || process.env.NODE_ENV === 'develepmont') {
   dotenv.config();
-  Logger.add(new winston.transports.Console({ format: winston.format.simple(), level: 'verbose' }));
+  Logger.add(new winston.transports.Console({ format: winston.format.combine(winston.format.colorize(), winston.format.simple()) , level: 'debug' }));
+  winston.addColors({
+    warn: 'yellow',
+    error: 'red',
+    crit: 'red',
+    info: 'blue'
+  });
 } else {
   Logger.add(new LoggingWinston({ projectId: process.env.PROJECT_ID, logName: 'discord-canvas', prefix: 'api' }));
   Logger.exceptions.handle(new LoggingWinston({ projectId: process.env.PROJECT_ID, logName: 'discord-canvas', prefix: 'api' }));

--- a/src/controllers/mesh.ts
+++ b/src/controllers/mesh.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+import { Mesh } from '../services/mesh';
+
+export class MeshController {
+  static router(): Router {
+    return Router({ caseSensitive: true })
+      .get('/', (req, res, next) => {
+        const shard = Mesh.register();
+        if (shard) {
+          res.send({ shardCount: Mesh.targetShards, ...shard});
+        } else {
+          res.sendStatus(204);
+        }
+        next();
+      })
+      .get('/status', (req, res, next) => {
+        const shards: any[] = [];
+        for (const id in Mesh.shards) {
+          shards.push({ id, ...Mesh.shards[id]});
+        }
+        res.send(shards);
+      })
+      .get('/:id', (req, res, next) => {
+        res.sendStatus(Mesh.heartbeat(req.params.id));
+        next();
+      })
+      .delete('/:id', (req, res, next) => {
+        Mesh.remove(req.params.id);
+        res.sendStatus(200);
+      });
+  }
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -6,6 +6,7 @@ import Compression from 'compression';
 import { HealthController } from './controllers/health';
 import { GuildController } from './controllers/guild';
 import { ReminderController } from './controllers/reminder';
+import { MeshController } from './controllers/mesh';
 
 export function applyRoutes(express: Express): Express {
   express.disable('etag');
@@ -18,6 +19,7 @@ export function applyRoutes(express: Express): Express {
   express.use('/health', HealthController.router());
   express.use('/guilds', GuildController.router());
   express.use('/reminders', ReminderController.router());
+  express.use('/mesh', MeshController.router());
 
   express.use((req: Request, res: Response, next: NextFunction) => {
     if (!res.writableFinished) {

--- a/src/services/mesh.ts
+++ b/src/services/mesh.ts
@@ -1,0 +1,93 @@
+import { Subscription, timer } from 'rxjs';
+import { Logger } from '../util/logger';
+import { v4 as uuidv4 } from 'uuid';
+import { getEpoch } from '../util';
+export type Shard = { shard: number, health: number, lastHeartbeat: number, state: 'pending' | 'running' | 'bad' };
+
+const MAX_HEALTH = 3;
+
+export class ShardMesh {
+  targetShards: number;
+  shards: Record<string, Shard>;
+
+  constructor() {
+    this.targetShards = Number.parseInt(process.env.TARGET_SHARDS || '1') || 1;
+    this.shards = {};
+    this.healthValidator();
+    Logger.info('initialized mesh');
+  }
+
+  healthValidator(): void {
+    timer(0, 15000).subscribe(() => {
+      for (const shardId in this.shards) {
+        const shard = this.shards[shardId];
+        if (shard.state == 'bad') {
+          this.remove(shardId);
+          continue;
+        }
+
+        if (shard.lastHeartbeat < getEpoch() - 15) {
+          shard.health -= 1;
+          Logger.warn(`Did not receive heartbeat from shard(${shard.shard}:${shardId}), health: ${shard.health}`);
+
+          if (shard.health <= 0) {
+            Logger.crit(`shard(${shard.shard}:${shardId}) health reached zero, marking as bad`);
+            shard.state = 'bad';
+          }
+        }
+      }
+    });
+  }
+
+  register(): { id: string, shard: number } | undefined {
+    const shard = this.missingShards()[0];
+    if (shard != null) {
+      const id = uuidv4();
+      Logger.info(`Registered new shard(${shard}) with id ${id}`);
+      this.shards[id] = { shard, health: MAX_HEALTH, lastHeartbeat: getEpoch(), state: 'pending' };
+      return { id, shard: this.shards[id].shard };
+    }
+
+    return undefined;
+  }
+
+  remove(id: string): void {
+    Logger.info(`removing shard with id ${id} from mesh`);
+    delete this.shards[id];
+  }
+
+  missingShards(): number[] {
+    return [...Array(this.targetShards).keys()]
+      .filter((i) => Object.keys(this.shards)
+        .map((id) => this.shards[id].shard)
+        .indexOf(i) === -1
+      );
+  }
+
+  heartbeat(id: string): 204 | 426 | 404 {
+    const shard = this.shards[id];
+    if (shard) {
+      if (shard.state == 'pending') {
+        shard.state = 'running';
+      } else if (shard.state == 'bad') {
+        // notify client that connection was marked as bad and remove connection
+        this.remove(id);
+        return 426;
+      }
+
+      shard.lastHeartbeat = getEpoch();
+      shard.health = Math.min(shard.health + 1, MAX_HEALTH);
+      return 204;
+    }
+
+    // notify client that connection was not found
+    // likely due to prolonged connection loss
+    return 404;
+  }
+}
+
+export function initMesh(): void {
+  Mesh = new ShardMesh();
+}
+
+export let Mesh: ShardMesh;

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,3 @@
+export function getEpoch(): number {
+  return Math.round(new Date().valueOf() / 1000);
+}

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -8,5 +8,15 @@ export function getLogger(): winston.Logger {
     level: 'info',
     format: winston.format.json(),
     transports: [],
+    levels: {
+      emerg: 0,
+      alert: 1,
+      crit: 2,
+      error: 3,
+      warn: 4,
+      notice: 5,
+      info: 6,
+      debug: 7
+    }
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,6 +375,11 @@
     "@types/mime" "*"
     "@types/node" "*"
 
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@typescript-eslint/eslint-plugin@^4.8.2":
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.8.2.tgz#cf9102ec800391caa574f589ffe0623cca1d9308"
@@ -2466,6 +2471,13 @@ run-parallel@^1.1.9:
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"
   integrity sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
 
+rxjs@^6.6.3:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -2822,7 +2834,7 @@ ts-node@^9.0.0:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
-tslib@^1.8.1:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -2943,7 +2955,7 @@ uuid@^3.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.0.0:
+uuid@^8.0.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
This pull request adds bot sharding capabilities to the api by giving bots a shard and ID.
managing:
- unresponsive shards
- disconnects
- shard distribution

Specify required shards in `.env` 
```
TARGET_SHARDS="2"
```
Target shards must be 1 or more.
Make sure that you host enough bot instances to reach the target shards. Running more than target shards is allowed, extra bots will be on standby until a shard becomes available.

Shard distribution priority correlates to the shard number. Meaning shard 0 will be assigned before shards with a higher number. Having the effect that shard 0 which will receive DMs on top of guild messages has the highest priority

API logs:
![2020-12-20-143457_604x75_scrot](https://user-images.githubusercontent.com/5513919/102714685-a2fc3300-42d0-11eb-9761-146f7e234008.png)

 2 Bot instances requesting a shard:
![2020-12-20-143709_1102x39_scrot](https://user-images.githubusercontent.com/5513919/102714734-e6ef3800-42d0-11eb-8c98-72c60ef0d400.png)


Future plans:
- Allow dynamic scaling of target shards
- Resume previous connections when taking over shards from defunct bots
